### PR TITLE
Draft: Use copier for project bootstrapping

### DIFF
--- a/Dockerfile.jinja
+++ b/Dockerfile.jinja
@@ -25,11 +25,11 @@ RUN wkhtmltopdf --enable-internal-links --enable-local-file-access \
 
 FROM docker.io/nginxinc/nginx-unprivileged:1.27-alpine
 
-LABEL maintainer="acend.ch"
-LABEL org.opencontainers.image.title="acend.ch's CHANGEME Basics Training"
-LABEL org.opencontainers.image.description="Container with acend.ch's CHANGEME Training content"
-LABEL org.opencontainers.image.authors="acend.ch"
-LABEL org.opencontainers.image.source="https://github.com/acend/changeme-training/"
+LABEL maintainer="{{ organization }}.ch"
+LABEL org.opencontainers.image.title="{{ organization }}.ch's {{ project_name }}"
+LABEL org.opencontainers.image.description="Container with {{ organization }}.ch's {{ project_name }} content"
+LABEL org.opencontainers.image.authors="{{ organization }}.ch"
+LABEL org.opencontainers.image.source="https://github.com/{{ repository }}"
 LABEL org.opencontainers.image.licenses="CC-BY-SA-4.0"
 
 EXPOSE 8080

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -1,4 +1,4 @@
-# CHANGEME Training
+# {{ project_name }}
 
 CHANGEME Training Description
 
@@ -50,6 +50,7 @@ hugo mod get -u
 
 #### `onlyWhen` and `onlyWhenNot`
 
+{% raw %}
 The `onlyWhen` and `onlyWhenNot` shortcodes allow text to be rendered if certain conditions apply.
 
 * `{{% onlyWhen variant1 %}}`: This is only rendered when `enabledModule` in `config.toml` contains `variant1`
@@ -67,6 +68,7 @@ This is only rendered when `enabledModule` in `config.toml` **does not** contain
 {{% /onlyWhen %}}
 ```
 
+{% endraw %}
 
 ## Build production image locally
 

--- a/copier.yaml
+++ b/copier.yaml
@@ -1,0 +1,22 @@
+project_name:
+  type: str
+  help: What is your project name?
+  placeholder: Helm Training
+
+project_slug:
+  type: str
+  help: What is the slug of your project?
+  default: "{{ project_name | lower | replace(' ', '-') }}"
+
+organization:
+  type: str
+  help: Which GitHub organization?
+  choices:
+    Acend: acend
+    Puzzle: puzzle
+  default: acend
+
+repository:
+  type: str
+  help: What is your Git repository?
+  default: "{{ organization }}/{{ project_slug }}"

--- a/package.json.jinja
+++ b/package.json.jinja
@@ -1,12 +1,12 @@
 {
-  "name": "changeme-training",
+  "name": "{{ project_slug }}",
   "version": "0.0.9",
-  "description": "changeme Training",
+  "description": "{{ project_name }}",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/changeme/changeme-training.git"
+    "url": "git+https://github.com/{{ repository }}.git"
   },
-  "author": "changeme",
+  "author": "{{ organization }}",
   "scripts": {
     "start": "bash -c \"docker run --rm --publish 8080:8080 -v $(pwd):/src:Z docker.io/klakegg/hugo:$(grep \"FROM docker.io/klakegg/hugo\" Dockerfile | sed 's/FROM docker.io\/klakegg\\/hugo://g' | sed 's/ AS builder//g') server -p 8080 --bind 0.0.0.0\"",
     "mdlint": "markdownlint --config .markdownlint.json content *.md",
@@ -14,9 +14,9 @@
     "prepare": "husky install"
   },
   "bugs": {
-    "url": "https://github.com/changeme/changeme-training/issues"
+    "url": "https://github.com/{{ repository }}/issues"
   },
-  "homepage": "https://github.com/changeme/changeme-training#readme",
+  "homepage": "https://github.com/{{ repository }}#readme",
   "devDependencies": {
     "husky": "9.1.7",
     "lint-staged": "15.2.10",

--- a/{{_copier_conf.answers_file}}.jinja
+++ b/{{_copier_conf.answers_file}}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier
+{{ _copier_answers|to_nice_yaml -}}


### PR DESCRIPTION
This is just an idea. The cool thing about Copier is that you can update the templates even after the initial bootstrap.

The Jinja syntax conflicts with the Go templates, so we would either need to escape it or template the Copier values to `hugo.yaml` and use those in the Hugo templates.

What do you think?